### PR TITLE
b10t331

### DIFF
--- a/src/Pages/Usuarios/Cadastrar/Form.js
+++ b/src/Pages/Usuarios/Cadastrar/Form.js
@@ -64,7 +64,7 @@ export class UserFormBuilder extends EditCreateForm {
                               <InputTextField
                                  id="usr_email"
                                  label="Email"
-                                 type="email"
+                                 type="text"
                                  maxLength="45"
                                  validated={this.state.validated}
                                  defaultValue={this.state.primaryData?.usr_email}


### PR DESCRIPTION
Foi trocado o tipo do campo de email para text para que ocorra a validação de forma correta

card relacionado: https://trello.com/c/IK8hJZef/331-bug-tentativa-de-cadastrar-um-usu%C3%A1rio-com-e-mail-inv%C3%A1lido