### PR TITLE
b10t346

### DIFF
--- a/src/Componentes/ListCompanies/index.js
+++ b/src/Componentes/ListCompanies/index.js
@@ -1,10 +1,7 @@
-import { Form } from 'react-bootstrap';
 import { React, Component } from 'react';
 import { request } from '../../Services/api';
 import PropTypes from 'prop-types'
-import { RequiredField, SelectValidateStyle } from '../../styles/CommonStyles';
-import { TextField, MenuItem } from '@mui/material';
-import NoDataComp from '../NoDataComp';
+import { MenuItem } from '@mui/material';
 import { DefaultValidateSelectField } from '../DefaultValidateInputs/DefaultValidateSelectField';
 
 export default class ListCompanies extends Component {
@@ -39,7 +36,6 @@ export default class ListCompanies extends Component {
          {...this.props}
          value={this.props.defaultCompany}
          label="Empresa">
-         <MenuItem value={""}><NoDataComp /></MenuItem>
          {this.state.companies?.map(company => {
             return (
                <MenuItem


### PR DESCRIPTION
Seletor mostrava 2 items com campos vazios ao ser ativado

Remove NoDataComp do componente ListCompanies, o qual estava gerando esse outro item vazio

card relacionado: https://trello.com/c/ERQoEFnG/346-bug-seletor-de-empresas-mostra-dois-items-vazios