### PR TITLE
Bug(Componente): Entrada de telefone agora aceita preenchimento vazio

### DIFF
--- a/src/Componentes/PhoneInput/index.js
+++ b/src/Componentes/PhoneInput/index.js
@@ -1,9 +1,12 @@
 import InputMask from "react-input-mask"
 import { DefaultValidationTextField } from "../DefaultValidateInputs/DefaultValidationTextField"
 export function PhoneInput(props) {
-   let mask = "(xx) xxxx-xxxx"
-   if (props.defaultValue.match(/ /g || []).length === 1) {
-      mask = "(xx) xxxxx-xxxx"
+   let mask = "(xx) xxxx-xxxxx"
+   if (props.defaultValue !== undefined) {
+      const emptySpaces = props.defaultValue.match(/ /g || [])
+      if (emptySpaces !== null && emptySpaces.length === 1) {
+         mask = "(xx) xxxxx-xxxx"
+      }
    }
    return <InputMask
       mask={mask}


### PR DESCRIPTION
O componente era incapaz de aceitar preenchimento vazio, como por exemplo na tela de cadastro de demanda ou usuário.

Agora a lógica condicional faz checagens de sanidade para certificar que está acessando atributos que existem

https://trello.com/c/vf9wcDod/347-campo-de-telefone-n%C3%A3o-aceitava-preenchimento-vazio