### PR TITLE
Bug(Componente): Campo de telefone alterava formatação de forma errada

### DIFF
--- a/src/Componentes/PhoneInput/index.js
+++ b/src/Componentes/PhoneInput/index.js
@@ -4,7 +4,7 @@ export function PhoneInput(props) {
    let mask = "(xx) xxxx-xxxxx"
    if (props.defaultValue !== undefined) {
       const emptySpaces = props.defaultValue.match(/ /g || [])
-      if (emptySpaces !== null && emptySpaces.length === 1) {
+      if (emptySpaces !== null && emptySpaces.length === 1 && props.defaultValue.length === 15) {
          mask = "(xx) xxxxx-xxxx"
       }
    }


### PR DESCRIPTION
Quando o campo é parcialmente preenchido e tentava enviar, a formatação mudava

Adiciona uma nova condicional para que isso não aconteça

https://trello.com/c/4M0ng7oP/350-telefone-%C3%A9-formatado-incorretamente-ao-tentar-enviar-um-formul%C3%A1rio-inv%C3%A1lido-e-o-preenchimento-do-telefone-est%C3%A1-incompleto