### PR TITLE
Resolve rejeição de b10t330

### DIFF
--- a/src/Componentes/DefaultValidateInputs/DefaultValidationTextField.js
+++ b/src/Componentes/DefaultValidateInputs/DefaultValidationTextField.js
@@ -12,15 +12,23 @@ function preventLeadingWhitespace(event) {
 export function DefaultValidationTextField(props) {
    let error = false
    let [valid, setValid] = useState()
+   let [HelperMessage, setMessage] = useState()
    useEffect(() => {
       if (props.valid) {
          props.valid.then((valid) => {
-            setValid(valid)
+            setValid(!!valid)
+            setMessage("")
+         }).catch((error) => {
+            setValid(false)
+            if (props.errorMessage) {
+               setMessage(props.errorMessage)
+            }
+            setMessage(error.message)
          })
       }
    })
    if (props.validated && props.required) {
-      if (props.errorMessage !== undefined) {
+      if (HelperMessage !== undefined) {
          error = true
       }
       else if (props.defaultValue == "" || props.defaultValue == null) {
@@ -44,8 +52,8 @@ export function DefaultValidationTextField(props) {
       error={error}
 
       helperText={props.required ?
-         (props.errorMessage ? props.errorMessage : "Campo Obrigatório")
-         : props.errorMessage}
+         (HelperMessage ? HelperMessage : "Campo Obrigatório")
+         : HelperMessage}
       {...props} />;
 
 

--- a/src/Componentes/PhoneInput/index.js
+++ b/src/Componentes/PhoneInput/index.js
@@ -2,7 +2,7 @@ import InputMask from "react-input-mask"
 import { DefaultValidationTextField } from "../DefaultValidateInputs/DefaultValidationTextField"
 export function PhoneInput(props) {
    let mask = "(xx) xxxx-xxxxx"
-   if (props.defaultValue !== undefined) {
+   if (props.defaultValue != undefined) {
       const emptySpaces = props.defaultValue.match(/ /g || [])
       if (emptySpaces !== null && emptySpaces.length === 1 && props.defaultValue.length === 15) {
          mask = "(xx) xxxxx-xxxx"

--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -16,6 +16,7 @@ import ListTypeDemand from '../../../Componentes/ListTypeDemand'
 import ListUsers from '../../../Componentes/ListUsers'
 import { PhoneInput } from '../../../Componentes/PhoneInput'
 import ContextLogin from '../../../Context/ContextLogin'
+import yup from '../../../Services/validations'
 import {
    BackGroundForm, BtnBlue, MainTable, TableData,
    TableHeader, TextCell, TitleRegister
@@ -31,6 +32,9 @@ export default function DemandForm(props) {
 export class DemandFormBuilder extends EditCreateForm {
    render() {
       const disableField = !(this.context.admin && this.paramRoute === 'inserir')
+      const emailValidator = yup.object().shape({
+         email: yup.string().email().required()
+      })
       return (
          <>
             {this.state.loading && this.paramRoute !== 'inserir'
@@ -71,6 +75,9 @@ export class DemandFormBuilder extends EditCreateForm {
                                  validated={this.state.validated}
                                  defaultValue={this.state.primaryData?.dem_contact_email}
                                  errorMessage={this.state.dem_contact_email}
+                                 valid={emailValidator.validate({
+                                    email: this.state.primaryData.dem_contact_email
+                                 })}
                                  onChange={this.context.admin ? this.handleChange : null}
                                  required
                               />

--- a/src/Pages/Usuarios/Cadastrar/Form.js
+++ b/src/Pages/Usuarios/Cadastrar/Form.js
@@ -12,7 +12,7 @@ import { IoChevronBackCircleSharp } from "react-icons/io5"
 import TextField from '@mui/material/TextField'
 import InputMask from "react-input-mask"
 import { PhoneInput } from '../../../Componentes/PhoneInput'
-import * as yup from 'yup'
+import yup from "../../../Services/validations"
 export default function UserForm(props) {
    return <UserFormBuilder insertDataEndpoint="usuarios/cadastrar"
       requestDataEndpoint="usuarios/procurar/"
@@ -71,7 +71,9 @@ export class UserFormBuilder extends EditCreateForm {
                                  validated={this.state.validated}
                                  defaultValue={this.state.primaryData?.usr_email}
                                  errorMessage={this.state.usr_email}
-                                 valid={emailValidator.isValid({ email: this.state.primaryData.usr_email })}
+                                 valid={emailValidator.validate({
+                                    email: this.state.primaryData.usr_email
+                                 })}
                                  onChange={this.handleChange}
                                  required
                               />

--- a/src/Services/validations.js
+++ b/src/Services/validations.js
@@ -1,0 +1,14 @@
+import * as yup from 'yup';
+
+yup.setLocale({
+   mixed: {
+      required: 'Campo Obrigatório'
+   },
+   string: {
+      email: 'E-mail inválido',
+      min: 'Valor muito curto (mínimo ${min} caracteres)',
+      max: 'Valor muito longo (máximo ${max} caracteres)'
+   },
+});
+
+export default yup;


### PR DESCRIPTION
Página de demandas não validava campo de email, agora valida.

Tradução da mensagem de erro da validação centralizada em um arquivo separado.

Comparação incompleta no componente de telefone atualizada para ser capaz de receber undefined ou null no campo que define seu conteúdo.