### PR TITLE
Feat(Pages): Adiciona validação para o campo de telefone

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -35,6 +35,11 @@ export class DemandFormBuilder extends EditCreateForm {
       const emailValidator = yup.object().shape({
          email: yup.string().email().required()
       })
+      const PhoneValidator = yup.object().shape({
+         phone: yup.string()
+            .trim()
+            .min(14, "Deve estar no formato (99) 9999-9999 ou (99) 99999-9999")
+      })
       return (
          <>
             {this.state.loading && this.paramRoute !== 'inserir'
@@ -89,6 +94,9 @@ export class DemandFormBuilder extends EditCreateForm {
                                  validated={this.state.validated}
                                  defaultValue={this.state.primaryData?.dem_contact_phone}
                                  errorMessage={this.state.dem_contact_phone}
+                                 valid={PhoneValidator.validate({
+                                    phone: this.state.primaryData.dem_contact_phone
+                                 })}
                                  onChange={this.context.admin ? this.handleChange : null}
                               />
                            </Col>

--- a/src/Pages/Usuarios/Cadastrar/Form.js
+++ b/src/Pages/Usuarios/Cadastrar/Form.js
@@ -21,8 +21,14 @@ export default function UserForm(props) {
 }
 export class UserFormBuilder extends EditCreateForm {
    render() {
-      let emailValidator = yup.object().shape({
+      const emailValidator = yup.object().shape({
          email: yup.string().email().required()
+      })
+      const PhoneValidator = yup.object().shape({
+         phone: yup.string()
+            .trim()
+            .min(14, "Deve estar no formato (99) 9999-9999 ou (99) 99999-9999")
+            .required()
       })
       return (
          <>
@@ -59,6 +65,9 @@ export class UserFormBuilder extends EditCreateForm {
                                  validated={this.state.validated}
                                  defaultValue={this.state.primaryData?.usr_phone}
                                  errorMessage={this.state.usr_phone}
+                                 valid={PhoneValidator.validate({
+                                    phone: this.state.primaryData.usr_phone
+                                 })}
                                  onChange={this.handleChange}
                                  required />
                            </Col>


### PR DESCRIPTION
Usa a validação do yup para garantir que o campo de telefone, se preenchido esteja no formato (99) 9999-9999 (99) 99999-9999

Card relacionado: https://trello.com/c/j0A7wjIp/352-campo-de-telefone-permanece-vermelho-quando-o-seu-conte%C3%BAdo-est%C3%A1-correto