### PR TITLE
B10t353

### DIFF
--- a/src/Pages/Log/index.js
+++ b/src/Pages/Log/index.js
@@ -221,7 +221,7 @@ class Log extends Component {
                                                 </Card.Title>
                                                 <Card.Subtitle className="mb-3 text-muted">{log.user.usr_name} - {displayDate(log.log_dtcreation)}</Card.Subtitle>
                                                 <Accordion.Collapse eventKey="0">
-                                                   <Card.Body style={{ padding: 0 }}><Table>
+                                                   <Card.Body style={{ padding: 0, overflowX: "scroll" }}><Table>
                                                       <TableHeader>
                                                          <TableRow>
                                                             <TextHeaderCell>Campo</TextHeaderCell>

--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -78,6 +78,24 @@ export const MainContainer = styled.div`
       color: #000;
    }
 
+   //estilização do scroll da tabela de logs
+   .addScroll {
+      ::-webkit-scrollbar {
+         width: 6px;
+         height: 10px;
+      }
+      ::-webkit-scrollbar-track {
+         background: #fff;       
+      }
+      ::-webkit-scrollbar-thumb {
+         background-color: rgba(0,0,0,0.1);   
+         border-radius: 20px;      
+      }
+      //estilização para firefox
+      scrollbar-width: thin;
+      scrollbar-color: rgba(0,0,0,0.1) #fff;
+   }
+
    @media (min-width: 767px){
       .positionButtonsFixed {
          margin-top: 8px;


### PR DESCRIPTION
Adicionado scroll na tabela de demonstração de dados na tela de logs

Adicionada uma nova classe de estilização que aplica os estilos no scroll, de forma que só aparece para mobile

card relacionado: https://trello.com/c/Tft2n3nl/353-bug-o-grid-de-logs-n%C3%A3o-est%C3%A1-efetuando-rolagem