### PR TITLE
Bug(Componente): Alerta tenta acessar ref inexistente

### DIFF
--- a/src/Componentes/CustomAlert/index.js
+++ b/src/Componentes/CustomAlert/index.js
@@ -31,7 +31,9 @@ export class CustomAlert extends React.Component {
       }
       this.setState({ showAlert: true })
       this.setContent(message, statusMsg)
-      this.myRef.current.scrollIntoView()
+      if (this.myRef.current) {
+         this.myRef.current.scrollIntoView()
+      }
       if (statusMsg === "success") {
          window.setTimeout(() => {
             this.props.redirectCallback()


### PR DESCRIPTION
Adiciona verificação pra quando o componente de alerta tenta acessar o ref usado para fazer scroll na página

https://trello.com/c/mU7OFZ9N/366-aplica%C3%A7%C3%A3o-quebra-quando-um-usu%C3%A1rio-comum-acessa-e-n%C3%A3o-tem-registros-na-p%C3%A1gina-de-demanda