### PR TITLE
b10t387

### DIFF
--- a/src/Componentes/CustomMenu/index.js
+++ b/src/Componentes/CustomMenu/index.js
@@ -71,7 +71,7 @@ export const CustomMenu = () => {
          {
             title: <span className="title-arrow">Horários <IoChevronForwardOutline size={17} /></span>,
             itemId: '/horario',
-            elemBefore: () => <IoCalendarOutline />
+            elemBefore: () => <IoCalendarOutline size={27} />
          },
          {
             title: <span className="title-arrow">Relatórios <IoChevronForwardOutline size={17} /></span>,


### PR DESCRIPTION
Alterado o tamanho do ícone para ficar alinhado com os demais itens do menu

card relacionado: https://trello.com/c/C16m6c9o/387-bug-o-texto-do-menu-hor%C3%A1rios-est%C3%A1-desalinhado-com-os-demais