### PR TITLE
b10t409

### DIFF
--- a/src/Services/api.js
+++ b/src/Services/api.js
@@ -56,7 +56,7 @@ export const request = async ({
          window.Eduzz.Accounts.logout({ env: "staging", redirectTo: window.location.origin })
          return
       } else if (result.data.meta.status === 204) {
-         window.location.replace("/demandas")
+         window.location.replace(process.env.PUBLIC_URL + "/demandas")
       }
 
       return result.data


### PR DESCRIPTION
Ao tentar acessar uma rota que não era permitida ao usuário, ele estava sendo direcionado para /demandas, sem a rota especifica 

card relacionado: https://trello.com/c/sEa1CpYe/409-bug-erro-quando-o-usu%C3%A1rio-n%C3%A3o-tem-permiss%C3%A3o-e-tenta-acessar-uma-rota
 