### PR TITLE
b10t415

### DIFF
--- a/src/Pages/Horarios/index.js
+++ b/src/Pages/Horarios/index.js
@@ -44,18 +44,20 @@ export function Horario() {
       }
       if (event.target.name === "cal_end" && currentItem.cal_cod === undefined) {
          // tratamento para a criação de novos horarios para o mesmo dia
-         if (populate[index].cal_day_of_week === days[days.length - 1].cal_day_of_week) {
-            if (populate[index].cal_end === days[days.length - 1].cal_end) {
-               if (populate[index].cal_start !== days[days.length - 1].cal_start) {
-                  return setDays([
-                     ...days, {
-                        ...populate[index],
-                        "cal_day_of_week": index,
-                        [event.target.name]: event.target.value
-                     }
-                  ])
+         if (days[days.length - 1] !== undefined) {
+            if (populate[index].cal_day_of_week === days[days.length - 1].cal_day_of_week) {
+               if (populate[index].cal_end === days[days.length - 1].cal_end) {
+                  if (populate[index].cal_start !== days[days.length - 1].cal_start) {
+                     return setDays([
+                        ...days, {
+                           ...populate[index],
+                           "cal_day_of_week": index,
+                           [event.target.name]: event.target.value
+                        }
+                     ])
+                  }
+                  return days[days.length - 1].cal_end = event.target.value
                }
-               return days[days.length - 1].cal_end = event.target.value
             }
          }
          setDays([


### PR DESCRIPTION
Arrumado o bug em que o consultor não conseguia adicionar um horário caso ele não tivesse nenhum horário preenchido 

card relacionado: https://trello.com/c/6sofD6lH/415-bug-n%C3%A3o-est%C3%A1-armazenando-os-hor%C3%A1rios-que-foram-cadastrados-pelo-consultor