### PR TITLE
b10t427

### DIFF
--- a/src/Pages/RelatorioGerencial/index.js
+++ b/src/Pages/RelatorioGerencial/index.js
@@ -107,7 +107,6 @@ export function RelatorioGerencial() {
          <Col style={{ paddingBottom: 30 }}>
             <Col md={{ offset: 2, span: 10 }}>
                <ButtonRow
-                  cancelButton={<Button variant="light" href="/demandas"><IoChevronBackCircleSharp size={30} color="#BFCADD" /></Button>}
                   titlePage={<Title>Relatório Gerencial</Title>}
                />
                <ResultadoSearchBar


### PR DESCRIPTION
Removido botão de voltar na página de relatório gerencial

card relacionado: https://trello.com/c/t6QZCR3x/427-bug-remover-o-bot%C3%A3o-de-voltar-no-relat%C3%B3rio-gerencial