### PR TITLE
B10t438

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -263,6 +263,8 @@ export const DemandForm = (props) => {
                                  let matches = primaryData.demandStatusHistories.filter((v) => event.target.value == v.dsh_sdm_cod)
                                  if (matches.length >= 1) {
                                     setFieldValue("dem_dtaction", new Date(matches[0].dsh_dtaction))
+                                 } else if (event.target.value === 2 || event.target.value === 3) {
+                                    setFieldValue("dem_dtaction", new Date())
                                  } else {
                                     setFieldValue("dem_dtaction", "")
                                  }
@@ -283,7 +285,9 @@ export const DemandForm = (props) => {
                      <Col className="mt-3" xs={6} sm={3} >
                         <DatePickerField
                            label="Data de Ação"
-                           name="dem_dtaction" />
+                           name="dem_dtaction"
+                           disabled={userRoles?.length !== 0 && (values.dem_sdm_cod === 2 || values.dem_sdm_cod === 3)}
+                        />
                      </Col>
                      {values.dem_sdm_cod !== 1 && values.dem_sdm_cod !== 5 ?
                         <Col className="mt-3" xs={6} sm={6} >

--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -297,6 +297,9 @@ export const DemandForm = (props) => {
                               disabled={userRoles?.includes("CONSULTOR") || values.dem_sdm_cod > 2}
                               onChange={!userRoles?.includes("CONSULTOR") && (async value => {
                                  setFieldValue("dem_dtmeet", value);
+                                 if (values.dem_sdm_cod === 2 && values.dem_dtaction !== '') {
+                                    setFieldValue("dem_dtaction", new Date())
+                                 }
                                  const data = await request({
                                     method: "get",
                                     endpoint: "calendar/get-free-time",


### PR DESCRIPTION
Ao alterar o status da demanda para agendado ou comparecido, é desativo o seletor de data de ação e o valor dela passa a ser o do dia em que foi alterado

Ao reagendar uma reunião, a data de ação passa a ser a do dia em que foi alterado

card relacionado: https://trello.com/c/rLcxHZUg/438-feature-bloquear-a-data-de-a%C3%A7%C3%A3o-para-pr%C3%A9-consultores-e-consultores