### PR TITLE
resolve b10t436

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -27,7 +27,7 @@ export const DemandForm = (props) => {
    const [freeTime, setFreeTime] = useState()
    const [contacts, setContacts] = useState()
    const [meetingDataRequest, setMeetingData] = useState()
-   const verifyStatus = userRoles?.length !== 2 && userRoles?.includes("CONSULTOR")
+   const disableDateMeeting = userRoles?.length !== 2 && userRoles?.includes("CONSULTOR")
    const [fields, setFields] = useState(
       {
          dem_title: "",
@@ -291,8 +291,8 @@ export const DemandForm = (props) => {
                            <MeetingDatePickerField
                               label="Data da Reunião"
                               name="dem_dtmeet"
-                              disabled={verifyStatus || values.dem_sdm_cod > 2}
-                              onChange={!verifyStatus && (async value => {
+                              disabled={disableDateMeeting || values.dem_sdm_cod > 2}
+                              onChange={!disableDateMeeting && (async value => {
                                  setFieldValue("dem_dtmeet", value);
                                  const data = await request({
                                     method: "get",

--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -27,6 +27,7 @@ export const DemandForm = (props) => {
    const [freeTime, setFreeTime] = useState()
    const [contacts, setContacts] = useState()
    const [meetingDataRequest, setMeetingData] = useState()
+   const verifyStatus = userRoles?.length !== 2 && userRoles?.includes("CONSULTOR")
    const [fields, setFields] = useState(
       {
          dem_title: "",
@@ -290,8 +291,8 @@ export const DemandForm = (props) => {
                            <MeetingDatePickerField
                               label="Data da Reunião"
                               name="dem_dtmeet"
-                              disabled={userRoles?.includes("CONSULTOR") || values.dem_sdm_cod > 2}
-                              onChange={!userRoles?.includes("CONSULTOR") && (async value => {
+                              disabled={verifyStatus || values.dem_sdm_cod > 2}
+                              onChange={!verifyStatus && (async value => {
                                  setFieldValue("dem_dtmeet", value);
                                  const data = await request({
                                     method: "get",


### PR DESCRIPTION
Ajusta o caso em que o usuário que tinha as duas jornadas não conseguia remarcar uma reunião 

card relacionado: https://trello.com/c/rLcxHZUg/438-feature-bloquear-a-data-de-a%C3%A7%C3%A3o-para-pr%C3%A9-consultores-e-consultores