### PR TITLE
resolve b10t441

### DIFF
--- a/src/Componentes/ListData/index.js
+++ b/src/Componentes/ListData/index.js
@@ -221,7 +221,8 @@ export default class ListarPagina extends Component {
                      />
                      <Row noGutters>
                         <MainTable noData={this.state.noData}
-                           className={`table-borderless ${(!this.state.noData && window.screen.width < 425) && 'table-responsive'}`}
+                           widthTable={window.screen.width}
+                           className={`table-borderless`}
                            style={{ marginBottom: 0 }}>
                            {this.state.responseData === null
                               ?

--- a/src/Componentes/ListData/index.js
+++ b/src/Componentes/ListData/index.js
@@ -220,7 +220,8 @@ export default class ListarPagina extends Component {
                         listSchedule={this.listSchedule}
                      />
                      <Row noGutters>
-                        <MainTable noData={this.state.noData} className={"table-borderless table-responsive"}
+                        <MainTable noData={this.state.noData}
+                           className={`table-borderless ${(!this.state.noData && window.screen.width < 425) && 'table-responsive'}`}
                            style={{ marginBottom: 0 }}>
                            {this.state.responseData === null
                               ?

--- a/src/Componentes/ListData/index.js
+++ b/src/Componentes/ListData/index.js
@@ -203,10 +203,10 @@ export default class ListarPagina extends Component {
       return <MainContainer>
          <MainRow>
             {/* Layout usado nesse componente deve ser repetido em custommenucol equivalente dentro do arquivo do componente */}
-            <CustomMenuCol><CustomMenu /></CustomMenuCol>
-            <Col lg={10}>
+            <CustomMenuCol lg={2}><CustomMenu /></CustomMenuCol>
+            <Col lg={{ span: 10, offset: 2 }}>
                <Col>
-                  <Container fluid>
+                  <Container fluid className="mt-3">
                      <CustomAlert
                         showAlertCallback={this.getAlertCallback.bind(this)}
                         redirectCallback={this.redirectCallback.bind(this)}
@@ -221,8 +221,7 @@ export default class ListarPagina extends Component {
                      />
                      <Row noGutters>
                         <MainTable noData={this.state.noData}
-                           widthTable={window.screen.width}
-                           className={`table-borderless`}
+                           className={`table-borderless ${(this.state.noData || window.screen.width <= 425) ? '' : 'table-responsive'}`}
                            style={{ marginBottom: 0 }}>
                            {this.state.responseData === null
                               ?

--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -197,7 +197,6 @@ export const Table = styled.table`
 export const MainTable = styled(Table)`
    ${(props) => props.noData && `
       margin-bottom: 0`}
-   ${(props) => !(props.noData && props.widthTable < 425) && 'table-responsive'}   
 `
 export const TableHeader = styled.thead`
 `

--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -197,6 +197,7 @@ export const Table = styled.table`
 export const MainTable = styled(Table)`
    ${(props) => props.noData && `
       margin-bottom: 0`}
+   ${(props) => !(props.noData && props.widthTable < 425) && 'table-responsive'}   
 `
 export const TableHeader = styled.thead`
 `


### PR DESCRIPTION
 Resolvido o caso em que a tela bugava ao não ter nenhum valor registado na tabela e que a exibição dos dados para mobile ficava desalinhada

card relacionado: https://trello.com/c/x2L5EwOr/441-bug-bug-visual-no-grid-de-demanda-no-firefox