### PR TITLE
resolve b10t445

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -271,7 +271,11 @@ export const DemandForm = (props) => {
                               if (primaryData && primaryData.demandStatusHistories.length >= 1) {
                                  let matches = primaryData.demandStatusHistories.filter((v) => event.target.value == v.dsh_sdm_cod)
                                  if (matches.length >= 1) {
-                                    setFieldValue("dem_dtaction", new Date(matches[0].dsh_dtaction))
+                                    if (event.target.value === 2 || event.target.value === 3) {
+                                       setFieldValue("dem_dtaction", new Date())
+                                    } else {
+                                       setFieldValue("dem_dtaction", new Date(matches[0].dsh_dtaction))
+                                    }
                                  } else if (event.target.value === 2 || event.target.value === 3) {
                                     setFieldValue("dem_dtaction", new Date())
                                  } else {


### PR DESCRIPTION
Ao alterar o status de uma demanda que já tinha um histórico, não estava sendo passado para a data de ação o dia atual, e sim o primeiro dia do histórico

card relacionado: https://trello.com/c/HWsRBtLD/445-bug-data-de-a%C3%A7%C3%A3o-n%C3%A3o-de-acordo-com-o-que-foi-requisitado