### PR TITLE
resolve b10t463

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -345,7 +345,7 @@ export const DemandForm = (props) => {
                      }
                   </Row>
                   {(values.dem_sdm_cod === 2 &&
-                     primaryData.dem_sdm_cod === 2 &&
+                     primaryData?.dem_sdm_cod === 2 &&
                      meetingDataRequest &&
                      !showButtons) &&
                      <Row className="d-flex justify-content-center mt-3 mb-3">


### PR DESCRIPTION
Ajustado bug que crashava tela ao selecionar o valor Agendando em Status de Demanda

card relacionado: https://trello.com/c/aBH0pSnw/463-bug-ao-alterar-o-status-para-agendado-a-tela-de-demanda-est%C3%A1-crashando