### PR TITLE
Resolve b10t491

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 PUBLIC_URL="/bfree-development"
 REACT_APP_PARTNER_CODE="a4b7ad1d-ebf7-43f8-af05-5cda0575c621"
 REACT_APP_EDUZZ_ENV="staging"
-REACT_APP_API_ENDPOINT="beta.atlanteti.com/bfree-api"
+REACT_APP_API_ENDPOINT="https://beta.atlanteti.com/bfree-api"

--- a/.env.staging
+++ b/.env.staging
@@ -1,4 +1,4 @@
 PUBLIC_URL="/bfree-staging"
 REACT_APP_PARTNER_CODE="a4b7ad1d-ebf7-43f8-af05-5cda0575c621"
 REACT_APP_EDUZZ_ENV="staging"
-REACT_APP_API_ENDPOINT="beta.atlanteti.com:18921/bfree-api"
+REACT_APP_API_ENDPOINT="https://beta.atlanteti.com:18921/bfree-api"

--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -373,7 +373,10 @@ export const DemandForm = (props) => {
                               <TableData>
                                  {freeTime.length > 0 ? freeTime.map((interval) => {
                                     return <TableRow>
-                                       <TextCell>{interval.cal_start}-{interval.cal_end}</TextCell>
+                                       {interval.cal_end ?
+                                          <TextCell>{interval.cal_start}-{interval.cal_end}</TextCell> :
+                                          <TextCell>{interval.cal_start}</TextCell>
+                                       }
                                     </TableRow>
                                  }) :
                                     <TableRow>
@@ -424,7 +427,6 @@ export const DemandForm = (props) => {
                                           "mee_cod": meetingCode,
                                           "mee_dem_cod": props.primaryId,
                                           "mee_start": dateStart,
-                                          "mee_end": dateEnd
                                        }
                                     })
                                     if (data.meta.status !== 100) {
@@ -434,18 +436,19 @@ export const DemandForm = (props) => {
                                        setContacts({
                                           consult: data.data.usuario.usr_email,
                                           client: data.data.demand.dem_contact_email,
-                                          time: moment(data.data.mee_start).format("DD/MM/YYYY - HH:mm")
+                                          time: moment(data.data.mee_start).format("DD/MM/YYYY - HH:mm"),
+                                          endTime: moment(data.data.mee_end).format("HH:mm")
                                        })
                                     }
                                  }}>
                                  {values.dem_hourmeet?.length == "5" ?
-                                    `Marcar Reunião De ${values.dem_hourmeet} a ${addTwoHours(values.dem_hourmeet)}` : "Escolha um horário"}</Button>
+                                    `Marcar Reunião De ${values.dem_hourmeet}` : "Escolha um horário"}</Button>
                            </Col>
                         </Row>
                         {contacts ?
                            <Row>
                               <Col>
-                                 Reunião marcada! Crie o evento e convide {contacts.consult} e {contacts.client} para a reunião de {contacts.time}
+                                 Reunião marcada! Crie o evento e convide {contacts.consult} e {contacts.client} para a reunião de {contacts.time} a {contacts.endTime}
                               </Col>
                            </Row>
                            : null}

--- a/src/Services/api.js
+++ b/src/Services/api.js
@@ -16,7 +16,7 @@ export const request = async ({
    const token = await cookieGetter.get("auth")
    const config = {
       method: method || 'get',
-      baseURL: `http://${baseUrl}/${endpoint}`,
+      baseURL: `${baseUrl}/${endpoint}`,
       data: data || null,
       params: params || null,
       timeout: 120000,


### PR DESCRIPTION
Card relacionado: https://trello.com/c/1OaZHs52/491-agendar-reuni%C3%A3o-sem-enviar-o-hor%C3%A1rio-final-e-usar-o-hor%C3%A1rio-que-o-back-manda-para-mostrar-a-hora-da-reuni%C3%A3o

Para testar: Vá em uma demanda em aberto e mude para agendado, tente marcar uma reunião num horário disponível