### PR TITLE
resolve b10t497

### DIFF
--- a/src/Pages/Log/index.js
+++ b/src/Pages/Log/index.js
@@ -236,7 +236,8 @@ class Log extends Component {
                                                                }
                                                                if (!key.includes("Data")) {
                                                                   if (key === "Inicio" || key === "Fim") {
-                                                                     if (newValue['Dia da Semana'] === undefined) {
+                                                                     // tanto a reunião como o cadastro de calendário tem as mesmas keys, por isso foi criada essa outra verificação
+                                                                     if (!(Object.keys(oldValue).includes('Dia da Semana') || Object.keys(newValue).includes('Dia da Semana'))) {
                                                                         return (
                                                                            <tr className="rowLogs table-borderless">
                                                                               <TextCell>{key}</TextCell>

--- a/src/Pages/Log/index.js
+++ b/src/Pages/Log/index.js
@@ -236,13 +236,15 @@ class Log extends Component {
                                                                }
                                                                if (!key.includes("Data")) {
                                                                   if (key === "Inicio" || key === "Fim") {
-                                                                     return (
-                                                                        <tr className="rowLogs table-borderless">
-                                                                           <TextCell>{key}</TextCell>
-                                                                           <TextCell>{oldValue ? displayDate(oldValue[key]) : ""}</TextCell>
-                                                                           <TextCell style={{ color: highlight ? "#4CAF50" : null }}>{newValue ? displayDate(newValue[key]) : ""}</TextCell>
-                                                                        </tr>
-                                                                     )
+                                                                     if (newValue['Dia da Semana'] === undefined) {
+                                                                        return (
+                                                                           <tr className="rowLogs table-borderless">
+                                                                              <TextCell>{key}</TextCell>
+                                                                              <TextCell>{oldValue ? displayDate(oldValue[key]) : ""}</TextCell>
+                                                                              <TextCell style={{ color: highlight ? "#4CAF50" : null }}>{newValue ? displayDate(newValue[key]) : ""}</TextCell>
+                                                                           </tr>
+                                                                        )
+                                                                     }
                                                                   }
                                                                   return (
                                                                      <tr className="rowLogs table-borderless">


### PR DESCRIPTION
Adicionado condicionais para o caso em que no log mostra os dados de Inicio e Fim
Os atributos tão retornado de duas formas, um em forma de string e o outro em formato de data, isso que estava gerando o erro

card relacionado: https://trello.com/c/dSOO9RE4/497-bug-exibi%C3%A7%C3%A3o-dos-dados-do-calend%C3%A1rio-de-forma-incorreta