### PR TITLE
resolve b10t495

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -197,7 +197,10 @@ export const DemandForm = (props) => {
                      const data = await request({
                         method: method,
                         endpoint: postEndpoint,
-                        data: values,
+                        data: {
+                           ...values,
+                           dem_dtaction: moment(values.dem_dtaction).format("YYYY-MM-DD")
+                        },
                      });
                      if (data.meta.status == 100) {
                         props.showAlert(data.meta)


### PR DESCRIPTION
Formata o dem_dtacion para enviar apenas data sem horário

card relacionado: https://trello.com/c/N9AvXKut/495-bug-verificar-quando-o-fuso-do-navegador-%C3%A9-diferente-porque-a-data-enviada-est%C3%A1-diferente