### PR TITLE
resolve b10t553

### DIFF
--- a/src/Pages/DadosBancarios/Cadastrar/Form.js
+++ b/src/Pages/DadosBancarios/Cadastrar/Form.js
@@ -37,9 +37,12 @@ export const DadosBancariosForm = (props) => {
             let tempFields = {}
             for (const key of Object.keys(fields)) {
                if (data.data[key] !== null) {
-                  tempFields[key] = data.data[key]
-               }
-               else {
+                  if (key.includes("cpf")) {
+                     tempFields[key] = cpfMask(data.data[key])
+                  } else {
+                     tempFields[key] = data.data[key]
+                  }
+               } else {
                   tempFields[key] = ""
                }
             }


### PR DESCRIPTION
Adicionado a mascara no cpf quando o usuário ja tem dado cadastrado

card relacionado: https://trello.com/c/TMtvvIXZ/553-bug-n%C3%A3o-est%C3%A1-sendo-adicionada-a-mascara-no-cpf-quando-o-usu%C3%A1rio-olha-os-dados-banc%C3%A1rios