### PR TITLE
resolve b10t557

### DIFF
--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -221,7 +221,7 @@ export const TableRow = styled.tr`
       white-space: nowrap;
       
       @media all and (max-width: 767px){
-         width: 20%;
+         width: 60%;
       }
    }
    td:first-child {


### PR DESCRIPTION
Ajustado caso que só aparecia um ícone das ações para mobile

card relacionado: https://trello.com/c/F7SEOPqk/557-bug-no-layout-responsivo-o-grid-n%C3%A3o-exibe-o-%C3%ADcone-da-lixeira