### PR TITLE
resolve b10t587

### DIFF
--- a/src/Pages/Demandas/Cadastrar/Form.js
+++ b/src/Pages/Demandas/Cadastrar/Form.js
@@ -203,7 +203,7 @@ export const DemandForm = (props) => {
                         endpoint: postEndpoint,
                         data: {
                            ...values,
-                           dem_dtaction: moment(values.dem_dtaction).format("YYYY-MM-DD")
+                           dem_dtaction: values.dem_dtaction === '' ? '' : moment(values.dem_dtaction).format("YYYY-MM-DD")
                         },
                      });
                      if (data.meta.status == 100) {


### PR DESCRIPTION
Não estava sendo possivel criar uma demanda, pois a data açao estava sendo enviada como invalida, quando a data era nula

card relacionado: https://trello.com/c/u3pY3Xbu/587-personalizar-mensagem-de-erro-da-data-de-a%C3%A7%C3%A3o