### PR TITLE
resolve b10t598

### DIFF
--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -13,6 +13,15 @@ export const UtilsFunctions = () => {
    const [qui, setQui] = useState(['div4'])
    const [sex, setSex] = useState(['div5'])
 
+   function editSameNewDay(event, currentItem) {
+      if (currentItem.length === undefined && currentItem.cam_cod === undefined) {
+         if (event.target.name === "cam_start") {
+            return days[days.length - 1].cam_start = event.target.value
+         } else {
+            return days[days.length - 1].cam_end = event.target.value
+         }
+      }
+   }
    function handleChange(event, index, currentItem) {
       setPopulate({
          ...populate, [index]: {
@@ -32,6 +41,13 @@ export const UtilsFunctions = () => {
                }
             ])
          }
+      }
+      if (currentItem.cam_start !== null && currentItem.cam_end !== null) {
+         editSameNewDay(event, currentItem)
+         return
+      }
+      if (Object.keys(currentItem).includes('cam_start') || Object.keys(currentItem).includes('cam_end')) {
+         currentItem[event.target.name] = event.target.value
       }
       if (event.target.name === "cam_end" && currentItem.cam_cod === undefined) {
          // tratamento para a criação de novos horarios para o mesmo dia

--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -13,13 +13,40 @@ export const UtilsFunctions = () => {
    const [qui, setQui] = useState(['div4'])
    const [sex, setSex] = useState(['div5'])
 
-   function editSameNewDay(event, currentItem) {
-      if (currentItem.length === undefined && currentItem.cam_cod === undefined) {
-         if (event.target.name === "cam_start") {
-            return days[days.length - 1].cam_start = event.target.value
-         } else {
-            return days[days.length - 1].cam_end = event.target.value
-         }
+   function editSameNewDay(event) {
+      if (event.target.name === "cam_start") {
+         return days[days.length - 1].cam_start = event.target.value
+      } else {
+         return days[days.length - 1].cam_end = event.target.value
+      }
+   }
+   function editExistingDay(event, index, currentItem) {
+      var filtered = days.filter(function (value) {
+         return value.cam_cod !== currentItem.cam_cod;
+      });
+      if (event.target.name === "cam_end") {
+         currentItem.cam_end = event.target.value
+         // é chamado quando esta sendo editado algum horario ja existente
+         return setDays([
+            ...filtered, {
+               ...populate[index],
+               "cam_day_of_week": index,
+               [event.target.name]: event.target.value,
+               "cam_cod": currentItem.cam_cod,
+               "cam_start": currentItem.cam_start
+            }
+         ])
+      } else {
+         currentItem.cam_start = event.target.value
+         return setDays([
+            ...filtered, {
+               ...populate[index],
+               "cam_day_of_week": index,
+               "cam_start": currentItem.cam_start,
+               "cam_cod": currentItem.cam_cod,
+               "cam_end": currentItem.cam_end
+            }
+         ])
       }
    }
    function handleChange(event, index, currentItem) {
@@ -42,11 +69,13 @@ export const UtilsFunctions = () => {
             ])
          }
       }
-      if (currentItem.cam_start !== null && currentItem.cam_end !== null) {
-         editSameNewDay(event, currentItem)
-         return
+      if (currentItem.length === undefined && currentItem.cam_cod === undefined) {
+         if (currentItem.cam_start !== null && currentItem.cam_end !== null) {
+            editSameNewDay(event, currentItem)
+            return
+         }
       }
-      if (Object.keys(currentItem).includes('cam_start') || Object.keys(currentItem).includes('cam_end')) {
+      if (currentItem.length === undefined) {
          currentItem[event.target.name] = event.target.value
       }
       if (event.target.name === "cam_end" && currentItem.cam_cod === undefined) {
@@ -76,33 +105,8 @@ export const UtilsFunctions = () => {
          ])
       }
       if (currentItem.cam_cod) {
-         var filtered = days.filter(function (value) {
-            return value.cam_cod !== currentItem.cam_cod;
-         });
-         if (event.target.name === "cam_end") {
-            currentItem.cam_end = event.target.value
-            // é chamado quando esta sendo editado algum horario ja existente
-            return setDays([
-               ...filtered, {
-                  ...populate[index],
-                  "cam_day_of_week": index,
-                  [event.target.name]: event.target.value,
-                  "cam_cod": currentItem.cam_cod,
-                  "cam_start": currentItem.cam_start
-               }
-            ])
-         } else {
-            currentItem.cam_start = event.target.value
-            return setDays([
-               ...filtered, {
-                  ...populate[index],
-                  "cam_day_of_week": index,
-                  "cam_start": currentItem.cam_start,
-                  "cam_cod": currentItem.cam_cod,
-                  "cam_end": currentItem.cam_end
-               }
-            ])
-         }
+         editExistingDay(event, index, currentItem)
+         return
       }
    }
    function addNewRow(currentArray, setArray) {

--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -12,8 +12,7 @@ export const UtilsFunctions = () => {
    const [qua, setQua] = useState(['div3'])
    const [qui, setQui] = useState(['div4'])
    const [sex, setSex] = useState(['div5'])
-
-   function editSameNewDay(event) {
+   function editNewDay(event) {
       if (event.target.name === "cam_start") {
          return days[days.length - 1].cam_start = event.target.value
       } else {
@@ -66,6 +65,7 @@ export const UtilsFunctions = () => {
       }
    }
    function handleChange(event, index, currentItem) {
+      let verifyEmptyField = Object.keys(currentItem).includes('cam_start') || Object.keys(currentItem).includes('cam_end')
       setPopulate({
          ...populate, [index]: {
             ...populate[index],
@@ -87,15 +87,33 @@ export const UtilsFunctions = () => {
       }
       if (currentItem.length === undefined && currentItem.cam_cod === undefined) {
          if (currentItem.cam_start !== null && currentItem.cam_end !== null) {
-            editSameNewDay(event, currentItem)
+            editNewDay(event, currentItem)
             return
          }
       }
-      if (currentItem.length === undefined) {
+      if (!verifyEmptyField) {
+         if (event.target.name === "cam_start") {
+            // trata caso de quando o horario se incia pelo final
+            if (days[days.length - 1].cam_start === null && days[days.length - 1].cam_end !== undefined) {
+               return days[days.length - 1].cam_start = event.target.value
+            }
+         }
+      }
+      if (verifyEmptyField) {
          currentItem[event.target.name] = event.target.value
       }
       if (event.target.name === "cam_end" && currentItem.cam_cod === undefined) {
-         // tratamento para a criação de novos horarios para o mesmo dia
+         if (!verifyEmptyField && populate[index] === undefined) {
+            // começa o preenchimento pelo horario final
+            return setDays([
+               ...days, {
+                  ...populate[index],
+                  "cam_day_of_week": index,
+                  "cam_start": null,
+                  [event.target.name]: event.target.value
+               }
+            ])
+         }
          if (days[days.length - 1] !== undefined) {
             createInSameDay(event, index)
          }

--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -49,6 +49,22 @@ export const UtilsFunctions = () => {
          ])
       }
    }
+   function createInSameDay(event, index) {
+      if (populate[index].cam_day_of_week === days[days.length - 1].cam_day_of_week) {
+         if (populate[index].cam_end === days[days.length - 1].cam_end) {
+            if (populate[index].cam_start !== days[days.length - 1].cam_start) {
+               return setDays([
+                  ...days, {
+                     ...populate[index],
+                     "cam_day_of_week": index,
+                     [event.target.name]: event.target.value
+                  }
+               ])
+            }
+            return days[days.length - 1].cam_end = event.target.value
+         }
+      }
+   }
    function handleChange(event, index, currentItem) {
       setPopulate({
          ...populate, [index]: {
@@ -81,20 +97,7 @@ export const UtilsFunctions = () => {
       if (event.target.name === "cam_end" && currentItem.cam_cod === undefined) {
          // tratamento para a criação de novos horarios para o mesmo dia
          if (days[days.length - 1] !== undefined) {
-            if (populate[index].cam_day_of_week === days[days.length - 1].cam_day_of_week) {
-               if (populate[index].cam_end === days[days.length - 1].cam_end) {
-                  if (populate[index].cam_start !== days[days.length - 1].cam_start) {
-                     return setDays([
-                        ...days, {
-                           ...populate[index],
-                           "cam_day_of_week": index,
-                           [event.target.name]: event.target.value
-                        }
-                     ])
-                  }
-                  return days[days.length - 1].cam_end = event.target.value
-               }
-            }
+            createInSameDay(event, index)
          }
          setDays([
             ...days, {

--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -63,6 +63,13 @@ export const UtilsFunctions = () => {
             return days[days.length - 1].cam_end = event.target.value
          }
       }
+      setDays([
+         ...days, {
+            ...populate[index],
+            "cam_day_of_week": index,
+            [event.target.name]: event.target.value
+         }
+      ])
    }
    function handleChange(event, index, currentItem) {
       let verifyEmptyField = Object.keys(currentItem).includes('cam_start') || Object.keys(currentItem).includes('cam_end')
@@ -91,10 +98,12 @@ export const UtilsFunctions = () => {
             return
          }
       }
-      if (!verifyEmptyField) {
+      if (!verifyEmptyField && populate[index] !== undefined) {
          if (event.target.name === "cam_start") {
             // trata caso de quando o horario se incia pelo final
             if (days[days.length - 1].cam_start === null && days[days.length - 1].cam_end !== undefined) {
+               return days[days.length - 1].cam_start = event.target.value
+            } else if (!(Object.keys(days[days.length - 1]).includes('cam_cod')) && days[days.length - 1].cam_day_of_week === index) { // altera o primeiro valor do novo horario sem criar um novo dia
                return days[days.length - 1].cam_start = event.target.value
             }
          }
@@ -116,14 +125,16 @@ export const UtilsFunctions = () => {
          }
          if (days[days.length - 1] !== undefined) {
             createInSameDay(event, index)
+            return
+         } else {
+            setDays([
+               ...days, {
+                  ...populate[index],
+                  "cam_day_of_week": index,
+                  [event.target.name]: event.target.value
+               }
+            ])
          }
-         setDays([
-            ...days, {
-               ...populate[index],
-               "cam_day_of_week": index,
-               [event.target.name]: event.target.value
-            }
-         ])
       }
       if (currentItem.cam_cod) {
          editExistingDay(event, index, currentItem)


### PR DESCRIPTION
Resolve caso de duplicidade de horarios

Refatora a função de handleChange

resolve caso em que começava o horario pelo final

card relacionado: https://trello.com/c/GA887AoB/598-bug-tela-de-configura%C3%A7%C3%A3o-de-calend%C3%A1rio-para-o-m%C3%AAs-enviando-parametros-errados