### PR TITLE
resolve b10t610

### DIFF
--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import moment from "moment";
-import { DivSpaceBtween, SubTitle, Title } from "../../styles/CommonStyles";
+import { DivSpaceBtween, SubTitle, Title, RightDivSchedule } from "../../styles/CommonStyles";
 import { Link } from "react-router-dom";
 import { Button } from "react-bootstrap";
 export const UtilsFunctions = () => {
@@ -263,9 +263,11 @@ export const TopTitles = (props) => {
          <SubTitle style={{ maxWidth: "70%" }}>
             Não adicione intervalos que entrem em conflito, ex: 10:00 -- 12:00 E 09:00 -- 11:00 do mesmo dia
          </SubTitle>
-         <Link to={props.route}>
-            <Button variant="dark">Ver {props.text}</Button>
-         </Link>
+         <RightDivSchedule>
+            <Link to={props.route}>
+               <Button variant="dark">Ver {props.text}</Button>
+            </Link>
+         </RightDivSchedule>
       </DivSpaceBtween>
    </>
 }

--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -410,10 +410,12 @@ export const DivSpaceBtween = styled.div`
    @media all and (max-width: 920px) {
       display: flex;
       flex-direction: column;
-
       button {
          margin-top: 1rem;
-         width: 25%
       }
    }
+`
+
+export const RightDivSchedule = styled.div`
+   max-width: 45vw; 
 `


### PR DESCRIPTION
Arruma caso em que para mobile ao clicar na linha do botao ia para outra pagina

card relacionado: https://trello.com/c/6SqOk7vf/612-refactor-organizar-a-tela-de-agendas-para-quando-a-resolu%C3%A7%C3%A3o-for-para-mobile