### PR TITLE
resolve b10t615

### DIFF
--- a/src/Pages/Horarios/Calendario/utils.js
+++ b/src/Pages/Horarios/Calendario/utils.js
@@ -44,9 +44,9 @@ export const UtilsHourCalendar = () => {
       if (verifyEmptyField && currentItem.cal_cod === undefined) {
          if (currentItem.cal_start === null && currentItem.cal_end !== null) {
             setPopulate([])
-            editExistinNewDay(event, currentItem)
+            return editExistinNewDay(event, currentItem)
          } else {
-            editExistinNewDay(event, currentItem)
+            return editExistinNewDay(event, currentItem)
          }
       }
       if (event.target.name === "cal_end" && currentItem.cal_cod === undefined) {

--- a/src/Pages/Horarios/utils.js
+++ b/src/Pages/Horarios/utils.js
@@ -96,6 +96,10 @@ export const UtilsFunctions = () => {
          if (currentItem.cam_start !== null && currentItem.cam_end !== null) {
             editNewDay(event, currentItem)
             return
+         } else if (currentItem.cam_start === null && currentItem.cam_end === null) {
+            // quando é um horario novo(que não seja o primeiro), é alterado o valor dele para que, posteriormente, seja tratado para qual caso ele sera direcionado
+            currentItem[event.target.name] = event.target.value
+            return
          }
       }
       if (!verifyEmptyField && populate[index] !== undefined) {


### PR DESCRIPTION
Resolve caso em que ao adicionar mais de um horario do final para o inicio, bugava ao enviar

Resolvido caso em que o seletor ficava congelado ao selecionar o horario final na tela de calendario(caso o item não fosse o primeiro) 
card relacionado: https://trello.com/c/9bfABzx3/615-hor%C3%A1rios-em-conflito-no-envio-da-requisi%C3%A7%C3%A3o