### PR TITLE
resolve b10t612

### DIFF
--- a/src/Componentes/HourComponent/index.js
+++ b/src/Componentes/HourComponent/index.js
@@ -45,10 +45,10 @@ export const HourComponent = (props) => {
             paddingBottom: 10,
             background: props.bgColor
          }}>
-            <Col xs={12} sm={1} lg={1}>
+            <Col xs={12} sm={2} lg={3} md={2}>
                <SubTitle className="mb-2">{props.dayOfWeek}</SubTitle>
             </Col>
-            <Col xs={12} sm={4} lg={2} md={{ offset: 2 }}>
+            <Col xs={12} sm={4} lg={2}>
                <SetHour
                   label="Inicial"
                   name="cam_start"
@@ -67,7 +67,7 @@ export const HourComponent = (props) => {
                   defaultValue={props.data[index].cam_end}
                />
             </Col>
-            <Col xs={12} sm={4} lg={2}>
+            <Col>
                <Row>
                   <CenterAlignDivToMobile style={{ cursor: 'pointer' }}>
                      <IoAddCircleOutline size={30} color="rgba(0,0,0,0.5)" onClick={props.onDuplicate} />
@@ -77,8 +77,8 @@ export const HourComponent = (props) => {
                   </CenterAlignDivToMobile>
                </Row>
             </Col>
-         </Row>
-      </Col>
+         </Row >
+      </Col >
    })
 }
 

--- a/src/Pages/Horarios/Calendario/index.js
+++ b/src/Pages/Horarios/Calendario/index.js
@@ -12,6 +12,11 @@ import CalendarPicker from '@mui/lab/CalendarPicker';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import moment from "moment"
+import { styled } from '@mui/material/styles';
+
+const Calendar = styled(CalendarPicker)({
+   maxWidth: '270px'
+})
 export function HorarioCalendario() {
    const {
       renderData,
@@ -85,7 +90,7 @@ export function HorarioCalendario() {
                      <LocalizationProvider dateAdapter={AdapterDateFns}>
                         <Row>
                            <Col xs={12} sm={6} md={5}>
-                              <CalendarPicker date={date} onChange={(newDate) => {
+                              <Calendar date={date} onChange={(newDate) => {
                                  setDate(newDate)
                                  renderDataComponent(newDate)
                               }} />


### PR DESCRIPTION
Ajusta caso em que um seletor ficava maior que o outro para um certo tipo de tela

Ajusta o calendario para quando a tela do celular for pequena

card relacionado: https://trello.com/c/6SqOk7vf/612-refactor-organizar-a-tela-de-agendas-para-quando-a-resolu%C3%A7%C3%A3o-for-para-mobile