### PR TITLE
resolve b10t625

### DIFF
--- a/src/Services/api.js
+++ b/src/Services/api.js
@@ -61,8 +61,9 @@ export const request = async ({
          return
       } else if (result.data.meta.status === 204) {
          window.location.replace(process.env.PUBLIC_URL + "/demandas")
+      } else if (result.data.meta.status === 216) {
+         window.location.replace(process.env.PUBLIC_URL + `/editar/dados/${Number(cookieGetter.cookies.user)}/alterar`)
       }
-
       return result.data
    } catch (error) {
       try {


### PR DESCRIPTION
Adiciona caso em que quando o consultor não tem os dados cadastrado redireciona para a tela de cadastrar dados

card relacionado: https://trello.com/c/UqyRQxzE/625-feature-bloquear-o-uso-do-sistema-se-o-usu%C3%A1rio-n%C3%A3o-houver-preenchido-os-dados-banc%C3%A1rios