### PR TITLE
resolve b10t627

### DIFF
--- a/src/Componentes/CustomMenu/index.js
+++ b/src/Componentes/CustomMenu/index.js
@@ -331,6 +331,7 @@ function ConsultorMenu(props) {
             vertical: 'top',
             horizontal: 'left',
          }}
+         disableScrollLock
       >
          <List>
             <ListItem button
@@ -379,6 +380,7 @@ function PreConsultorMenu(props) {
             vertical: 'top',
             horizontal: 'left',
          }}
+         disableScrollLock
       >
          <List>
             <ListItem button


### PR DESCRIPTION
Resolve caso em que ao clicar nos submenus o scroll das paginas travavam para resoluções mobile

card relacionado: https://trello.com/c/mZyV4zeb/627-bug-aplica%C3%A7%C3%A3o-travando-para-mobile-quando-o-usu%C3%A1rio-%C3%A9-consultor-pre