### PR TITLE
resolve b10t636

### DIFF
--- a/src/Componentes/SearchBar/index.js
+++ b/src/Componentes/SearchBar/index.js
@@ -41,7 +41,6 @@ export default class SearchBar extends Component {
       }))
    }
    handleSubmit(event) {
-      // TODO: Enviar a data formatada
       const { formData } = this.state
       const { dtActionBegin, dtActionEnd } = this.filter
       event.preventDefault()
@@ -51,7 +50,9 @@ export default class SearchBar extends Component {
 
    requestExportData(event, endpointExport, nameFile) {
       event.preventDefault()
-      let data = this.props.exportData({ extraParams: this.state.formData, endpointExport, nameFile })
+      const { formData } = this.state
+      const { dtActionBegin, dtActionEnd } = this.filter
+      let data = this.props.exportData({ extraParams: { ...formData, dtActionBegin, dtActionEnd }, endpointExport, nameFile })
       return
    }
 

--- a/src/Componentes/SearchBar/index.js
+++ b/src/Componentes/SearchBar/index.js
@@ -44,16 +44,21 @@ export default class SearchBar extends Component {
       const { formData } = this.state
       const { dtActionBegin, dtActionEnd } = this.filter
       event.preventDefault()
-      this.props.filterData({ extraParams: { ...formData, dtActionBegin, dtActionEnd } })
-      return
+      if (formData.dem_sdm_cod !== 3) { // when status demand is different from Comparecido
+         return this.props.filterData({ extraParams: formData })
+      }
+      return this.props.filterData({ extraParams: { ...formData, dtActionBegin, dtActionEnd } })
+
    }
 
    requestExportData(event, endpointExport, nameFile) {
       event.preventDefault()
       const { formData } = this.state
       const { dtActionBegin, dtActionEnd } = this.filter
-      let data = this.props.exportData({ extraParams: { ...formData, dtActionBegin, dtActionEnd }, endpointExport, nameFile })
-      return
+      if (formData.dem_sdm_cod !== 3) { // when status demand is different from Comparecido
+         return this.props.exportData({ extraParams: formData, endpointExport, nameFile })
+      }
+      return this.props.exportData({ extraParams: { ...formData, dtActionBegin, dtActionEnd }, endpointExport, nameFile })
    }
 
    requestSchedule(event) {


### PR DESCRIPTION
Corrigi caso em que ao adicionar data no Status Comparecido, não enviava o arquivo enviando a data

Corrigi caso em que ao adicionar a data e alterar para outro status, a data continuava sendo enviada

card relacionado: https://trello.com/c/czYLQioy/636-refactor-adicionar-os-valores-das-datas-ao-fazer-download-da-planilha-em-comparecido